### PR TITLE
remove .nvm by default

### DIFF
--- a/dkan2-installation.sh
+++ b/dkan2-installation.sh
@@ -12,6 +12,9 @@ echo "DKAN2 Installation: installing prerequisite packages"
 echo -e "----------\e[39m"
 apt install apt-transport-https ca-certificates curl software-properties-common -y
 
+# if nvm installed, remove
+rm -Rf /home/$1 .nvm
+
 # install nvm
 echo -e "\e[34m----------"
 echo "DKAN2 Installation: install NVM"


### PR DESCRIPTION
Jamey mentioned that if nvm is already installed, an attempt to install it again raises an error. To get round this I've just removed .nvm before an installation. Even if there is no .nvm dir, then removing it won't throw an error, it will just let you know the given directory does not exist